### PR TITLE
Removed try-catch from script, add regex to replace newline

### DIFF
--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -1,17 +1,13 @@
 import json;
-import sys;
 from deepface import DeepFace;
 
-try:
-    result = DeepFace.analyze(
-        img_path = "{{img_path}}",
-        actions={{actions}},
-        enforce_detection={{enforce_detection}},
-        anti_spoofing={{anti_spoofing}},
-        detector_backend="{{detector_backend}}",
-        align={{align}},
-        silent={{silent}},
-    );
-    print(json.dumps(result, default=str))
-except ValueError as e:
-    print(json.dumps({"error": str(e)}), file=sys.stderr)
+result = DeepFace.analyze(
+    img_path = "{{img_path}}",
+    actions={{actions}},
+    enforce_detection={{enforce_detection}},
+    anti_spoofing={{anti_spoofing}},
+    detector_backend="{{detector_backend}}",
+    align={{align}},
+    silent={{silent}},
+);
+print(json.dumps(result, default=str))

--- a/scripts/extract_faces.py
+++ b/scripts/extract_faces.py
@@ -1,18 +1,14 @@
 import json;
-import sys;
 from deepface import DeepFace;
 
-try:
-    result = DeepFace.extract_faces(
-        img_path = "{{img_path}}",
-        target_size={{target_size}},
-        enforce_detection={{enforce_detection}},
-        anti_spoofing={{anti_spoofing}},
-        detector_backend="{{detector_backend}}",
-        align={{align}},
-        grayscale={{grayscale}},
-    );
+result = DeepFace.extract_faces(
+    img_path = "{{img_path}}",
+    target_size={{target_size}},
+    enforce_detection={{enforce_detection}},
+    anti_spoofing={{anti_spoofing}},
+    detector_backend="{{detector_backend}}",
+    align={{align}},
+    grayscale={{grayscale}},
+);
 
-    print(json.dumps(result, default=str))
-except ValueError as e:
-    print(json.dumps({"error": str(e)}), file=sys.stderr)
+print(json.dumps(result, default=str))

--- a/scripts/find.py
+++ b/scripts/find.py
@@ -1,20 +1,16 @@
 from deepface import DeepFace;
-import sys;
 
-try:
-    result = DeepFace.find(
-        img_path = "{{img_path}}",
-        db_path = "{{db_path}}",
-        model_name = "{{model_name}}",
-        distance_metric = "{{distance_metric}}",
-        enforce_detection = {{enforce_detection}},
-        anti_spoofing={{anti_spoofing}},
-        detector_backend = "{{detector_backend}}",
-        align = {{align}},
-        normalization = "{{normalization}}",
-        silent = {{silent}}
-    );
+result = DeepFace.find(
+    img_path = "{{img_path}}",
+    db_path = "{{db_path}}",
+    model_name = "{{model_name}}",
+    distance_metric = "{{distance_metric}}",
+    enforce_detection = {{enforce_detection}},
+    anti_spoofing={{anti_spoofing}},
+    detector_backend = "{{detector_backend}}",
+    align = {{align}},
+    normalization = "{{normalization}}",
+    silent = {{silent}}
+);
 
-    print(result[0].to_json())
-except ValueError as e:
-    print(json.dumps({"error": str(e)}), file=sys.stderr)
+print(result[0].to_json())

--- a/scripts/represent.py
+++ b/scripts/represent.py
@@ -1,19 +1,14 @@
 import json;
-import sys;
 from deepface import DeepFace;
 
-try:
-    result = DeepFace.represent(
-        img_path = "{{img_path}}",
-        model_name = "{{model_name}}",
-        enforce_detection = {{enforce_detection}},
-        anti_spoofing = "{{anti_spoofing}}",
-        detector_backend = "{{detector_backend}}",
-        align = {{align}},
-        normalization = "{{normalization}}"
-    );
+result = DeepFace.represent(
+    img_path = "{{img_path}}",
+    model_name = "{{model_name}}",
+    enforce_detection = {{enforce_detection}},
+    anti_spoofing = "{{anti_spoofing}}",
+    detector_backend = "{{detector_backend}}",
+    align = {{align}},
+    normalization = "{{normalization}}"
+);
 
-    print(json.dumps(result, default=str))
-except ValueError as e:
-    print(json.dumps({"error": str(e)}), file=sys.stderr)
-
+print(json.dumps(result, default=str))

--- a/scripts/verify.py
+++ b/scripts/verify.py
@@ -1,20 +1,16 @@
 import json;
-import sys;
 from deepface import DeepFace;
 
-try:
-    result = DeepFace.verify(
-        img1_path = "{{img1_path}}",
-        img2_path = "{{img2_path}}",
-        enforce_detection = {{enforce_detection}},
-        anti_spoofing={{anti_spoofing}},
-        align = {{align}},
-        model_name = "{{model_name}}",
-        detector_backend = "{{detector_backend}}",
-        distance_metric = "{{distance_metric}}",
-        normalization = "{{normalization}}"
-    );
+result = DeepFace.verify(
+    img1_path = "{{img1_path}}",
+    img2_path = "{{img2_path}}",
+    enforce_detection = {{enforce_detection}},
+    anti_spoofing={{anti_spoofing}},
+    align = {{align}},
+    model_name = "{{model_name}}",
+    detector_backend = "{{detector_backend}}",
+    distance_metric = "{{distance_metric}}",
+    normalization = "{{normalization}}"
+);
 
-    print(json.dumps(result, default=str))
-except ValueError as e:
-    print(json.dumps({"error": str(e)}), file=sys.stderr)
+print(json.dumps(result, default=str))

--- a/src/DeepFace.php
+++ b/src/DeepFace.php
@@ -19,8 +19,10 @@ use Astrotomic\DeepFace\Enums\Normalization;
 use Astrotomic\DeepFace\Enums\Race;
 use Astrotomic\DeepFace\Exceptions\DeepFaceException;
 use BadMethodCallException;
+use Exception;
 use InvalidArgumentException;
 use SplFileInfo;
+use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
 
@@ -306,41 +308,43 @@ class DeepFace
 
     protected function run(string $filepath, array $data): array|bool
     {
-        $script = $this->script($filepath, $data);
-        $process = $this->process($script);
+        try {
+            $script = $this->script($filepath, $data);
+            $process = $this->process($script);
 
-        $output = $process
-            ->mustRun()
-            ->getOutput();
+            $output = $process
+                ->mustRun()
+                ->getOutput();
 
-        $errorOutput = $process->getErrorOutput();
+            $lines = array_values(array_filter(explode(PHP_EOL, $output), function (string $line): bool {
+                json_decode($line, true);
 
-        if(!empty($errorOutput)) {
-            if (preg_match_all('/\{(?:[^{}]|(?R))*\}/', $errorOutput, $matches)) {
-                $lastJson = end($matches[0]);
-                $errorResult = json_decode($lastJson, true);
+                return json_last_error() === JSON_ERROR_NONE;
+            }));
 
-                if ($errorResult !== null && isset($errorResult['error'])) {
-                    throw new DeepFaceException($errorResult['error']);
+            if (empty($lines)) {
+                throw new BadMethodCallException('Python deepface script has not returned with any JSON.');
+            }
+
+            $json = $lines[0];
+
+            return json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+        } catch(Exception $e) {
+            if($e instanceof ProcessFailedException) {
+                $fullMessage = $e->getMessage();
+
+                if (preg_match('/ValueError: (.*)/', $fullMessage, $matches)) {
+                    $errorMessage = $matches[1];
+                    throw new DeepFaceException(trim(strval($errorMessage)));
                 } else {
-                    throw new DeepFaceException("Failed to parse error message: " . $lastJson);
+                    // Should return this or $fullMessage?
+                    throw new BadMethodCallException("Couldn't get the error message.");
                 }
+            } else {
+                // Should return the exception message?
+                throw new BadMethodCallException("Something went wrong.");
             }
         }
-
-        $lines = array_values(array_filter(explode(PHP_EOL, $output), function (string $line): bool {
-            json_decode($line, true);
-
-            return json_last_error() === JSON_ERROR_NONE;
-        }));
-
-        if (empty($lines)) {
-            throw new BadMethodCallException('Python deepface script has not returned with any JSON.');
-        }
-
-        $json = $lines[0];
-
-        return json_decode($json, true, 512, JSON_THROW_ON_ERROR);
     }
 
     protected function process(string $script): Process
@@ -362,6 +366,8 @@ class DeepFace
 
         $script = trim(strtr($template, $data));
 
-        return str_replace(PHP_EOL, ' ', $script);
+        $newline_regex = '/(\r\n)|\r|\n/';
+
+        return preg_replace($newline_regex, ' ', $script);
     }
 }


### PR DESCRIPTION
Last pull request (#14) introduced a serious problem when running any script in a single line (python won't run a script with a try-except block in a single line because indentations, see #15 for more details).

Also, running the package on a linux-based server throws an error related with newline not being replaced correctly.

This PR should address all of this.