### PR TITLE
Fix: handle RetinaFace landmarks correctly (nose, mouth_left and mouth_right)

### DIFF
--- a/src/Data/FacialArea.php
+++ b/src/Data/FacialArea.php
@@ -13,6 +13,9 @@ class FacialArea implements JsonSerializable
         public readonly int $h,
         public readonly int|array|null $left_eye,
         public readonly int|array|null $right_eye,
+        public readonly int|array|null $nose,
+        public readonly int|array|null $mouth_left,
+        public readonly int|array|null $mouth_right,
     ) {}
 
     public function jsonSerialize(): array


### PR DESCRIPTION
This PR fixes [#23](https://github.com/Astrotomic/php-deepface/issues/23).

- Issue: `Unknown named parameter $nose` when using `Detector::RETINAFACE`
- Cause: RetinaFace returns landmarks (`nose`, `mouth_left`, `mouth_right`, etc.) not properly mapped.
- Fix: Normalize landmark keys before constructing the object.

Tested with:
- `Detector::RETINAFACE`
- `FaceRecognitionModel::ARCFACE`

Result: `represent()` now returns embeddings successfully without crashing.